### PR TITLE
fix: add callback validation to SourceInfoEventListener

### DIFF
--- a/src/core/event/listener.ts
+++ b/src/core/event/listener.ts
@@ -203,6 +203,7 @@ export class SourceInfoEventListener extends EventListener {
   ) {
     super(name, errorHandler);
     this.callback = callback;
+    this.validateCallback();
   }
 
   public async handleEvent(event: BaseEvent): Promise<void> {
@@ -219,6 +220,12 @@ export class SourceInfoEventListener extends EventListener {
       }
     } catch (error) {
       this.handleError(error as Error, event);
+    }
+  }
+
+  private validateCallback(): void {
+    if (typeof this.callback !== 'function') {
+      throw new Error('SourceInfoEventCallback must be a function');
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes a small inconsistency in the event listener validation logic by adding callback validation to the `SourceInfoEventListener` class.

## Changes
- Added a private `validateCallback()` method to `SourceInfoEventListener` that checks if the callback is a function
- Updated the constructor to call `validateCallback()` after assigning the callback
- This matches the existing behavior in `FunctionEventListener` for consistency

## Motivation
The `FunctionEventListener` class already validates its callback in the constructor, but `SourceInfoEventListener` did not. This could lead to runtime errors if an invalid (non-function) callback is passed. Adding this validation ensures robustness and maintains code consistency across the event listener implementations.

## Testing
- No new tests added, but existing validation logic is now consistent
- Verified no lint/compile errors after the change
- The fix is minimal and follows the same pattern as the existing code