### PR TITLE
Replace deprecated substr with slice in EventListener ID generation

### DIFF
--- a/src/core/event/listener.ts
+++ b/src/core/event/listener.ts
@@ -49,7 +49,7 @@ export abstract class EventListener {
   private static readonly listenerRegistry = new WeakSet<EventListener>();
 
   constructor(name: string, errorHandler?: ErrorCallback) {
-    this.id = `listener_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    this.id = `listener_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
     this.name = name;
     this.errorHandler = errorHandler;
 


### PR DESCRIPTION
## Description
This PR fixes a small bug in the EventListener class by replacing the deprecated `substr` method with the modern `slice` method in the ID generation logic.

## Changes Made
- Updated `/src/core/event/listener.ts` line 47: Changed `Math.random().toString(36).substr(2, 9)` to `Math.random().toString(36).slice(2, 11)`

## Why This Change
- The `substr` method has been deprecated in favor of `slice` for better consistency with other JavaScript APIs
- Using `slice` follows current best practices and ensures future compatibility
- The functionality remains exactly the same - both methods extract 9 characters starting from index 2 of the random string

## Testing
- No behavioral changes expected
- ID generation will continue to work identically
- Code should pass all existing tests without modification

## Impact
- Low risk change with no breaking changes
- Improves code quality and maintainability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated event ID generation for listeners. Newly created IDs may exhibit minor variations in length/format compared to previous releases.
  * Existing IDs remain unchanged; only newly generated IDs use the updated scheme.
  * No changes to public APIs or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->