### PR TITLE
Add CI workflow for lint and type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI - Lint and Type Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:check
+
+      - name: Type check
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src/**/*.ts --fix",
     "lint:check": "eslint src/**/*.ts",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "clean": "rimraf dist",


### PR DESCRIPTION
## Description
Adds a GitHub Actions CI workflow to run linting and TypeScript type checking on every push and pull request to the `main` branch.

## Changes
- Added `typecheck` npm script to `package.json` for running `tsc --noEmit`
- Created `.github/workflows/ci.yml` with:
  - Matrix testing on Node.js 18.x and 20.x
  - npm caching for faster builds
  - Steps: checkout, install dependencies, lint check, type check

## Testing
- Workflow will trigger on push/PR to `main`
- Run locally with:
  ```bash
  npm run lint:check
  npm run typecheck